### PR TITLE
UI/login

### DIFF
--- a/android/app/src/main/java/com/emergsaver/mediquick/CheckEmail.java
+++ b/android/app/src/main/java/com/emergsaver/mediquick/CheckEmail.java
@@ -44,15 +44,21 @@ public class CheckEmail extends AppCompatActivity {
         findViewById(R.id.btnVerifyDone).setOnClickListener(v -> {
             FirebaseUser u = auth.getCurrentUser();
             if (u == null) {
-                Toast.makeText(this, "세션이 만료되었습니다. 다시 로그인해 주세요.", Toast.LENGTH_SHORT).show();
+                // InsertActivity에서 이제는 signOut하지 않지만, 앱 재시작 등으로 세션이 사라졌을 수 있음
+                Toast.makeText(this, "세션이 만료되었거나 앱이 재시작되었습니다. 로그인해 주세요.", Toast.LENGTH_SHORT).show();
+                startActivity(new Intent(this, LoginActivity.class));
                 finish();
                 return;
             }
 
             u.reload().addOnCompleteListener(t -> {
                 if (u.isEmailVerified()) {
-                    Toast.makeText(this, "인증이 완료되었습니다. 로그인해 주세요.", Toast.LENGTH_SHORT).show();
-                    startActivity(new Intent(this, LoginActivity.class));
+                    Toast.makeText(this, "가입완료! 로그인 해주세요", Toast.LENGTH_LONG).show();
+                    // 로그인 화면으로 보내기 전에 세션 정리
+                    auth.signOut();
+                    Intent i = new Intent(this, LoginActivity.class);
+                    i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+                    startActivity(i);
                     finish();
                 } else {
                     Toast.makeText(this, "아직 인증되지 않았습니다. 메일의 링크를 눌러주세요.", Toast.LENGTH_SHORT).show();
@@ -65,6 +71,7 @@ public class CheckEmail extends AppCompatActivity {
             FirebaseUser u = auth.getCurrentUser();
             if (u == null) {
                 Toast.makeText(this, "세션이 만료되었습니다. 다시 로그인해 주세요.", Toast.LENGTH_SHORT).show();
+                startActivity(new Intent(this, LoginActivity.class));
                 finish();
                 return;
             }

--- a/android/app/src/main/java/com/emergsaver/mediquick/InsertActivity.java
+++ b/android/app/src/main/java/com/emergsaver/mediquick/InsertActivity.java
@@ -325,35 +325,26 @@ public class InsertActivity extends AppCompatActivity {
         String pw2   = textOf(etPw2);
 
         String rawPhone = textOf(etPhone).trim().replaceAll("[^0-9]", "");
-        String phone = (rawPhone.length() == 9)
-                ? rawPhone.substring(0,3) + "-" + rawPhone.substring(3,7) + "-" + rawPhone.substring(7)
-                : textOf(etPhone).trim();
         int y = getSel(spYear), m = getSel(spMonth), d = getSel(spDay);
         boolean ok = true;
 
         if (!name.matches("^[A-Za-z가-힣]{2,16}$")) {
-            if (tilName != null) tilName.setError("이름은 2~16자여야 합니다.");
-            ok = false;
+            if (tilName != null) tilName.setError("이름은 2~16자여야 합니다."); ok = false;
         }
         if (!( !TextUtils.isEmpty(email) && Patterns.EMAIL_ADDRESS.matcher(email).matches() )) {
-            if (tilEmail != null) tilEmail.setError("이메일 형식을 확인해 주세요.");
-            ok = false;
+            if (tilEmail != null) tilEmail.setError("이메일 형식을 확인해 주세요."); ok = false;
         }
         if (!isPasswordValid(pw)) {
-            if (tilPw != null) tilPw.setError("8~16자, 영문+숫자 조합이어야 합니다.");
-            ok = false;
+            if (tilPw != null) tilPw.setError("8~16자, 영문+숫자 조합이어야 합니다."); ok = false;
         }
         if (!pw.equals(pw2)) {
-            if (tilPw2 != null) tilPw2.setError("비밀번호가 일치하지 않습니다.");
-            ok = false;
+            if (tilPw2 != null) tilPw2.setError("비밀번호가 일치하지 않습니다."); ok = false;
         }
-        if (phone.length() != 11) {
-            if (tilPhone != null) tilPhone.setError("전화번호 11자리를 입력하세요.");
-            ok = false;
+        if (rawPhone.length() != 11) {
+            if (tilPhone != null) tilPhone.setError("전화번호 11자리를 입력하세요."); ok = false;
         }
         if (!isValidDate(y, m, d)) {
-            Toast.makeText(this, "생년월일을 확인해 주세요.", Toast.LENGTH_SHORT).show();
-            ok = false;
+            Toast.makeText(this, "생년월일을 확인해 주세요.", Toast.LENGTH_SHORT).show(); ok = false;
         }
         return ok;
     }

--- a/android/app/src/main/res/layout/activity_insert.xml
+++ b/android/app/src/main/res/layout/activity_insert.xml
@@ -57,7 +57,9 @@
                 android:id="@+id/etName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="이름 입력" />
+                android:hint="이름 입력"
+                android:inputType="textPersonName"
+                android:imeOptions="actionNext" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <TextView

--- a/android/app/src/main/res/layout/fragment_profile.xml
+++ b/android/app/src/main/res/layout/fragment_profile.xml
@@ -15,19 +15,19 @@
         android:orientation="vertical"
         android:padding="16dp">
 
-        <!-- 상단: 프로필 사진 + 설정 버튼 -->
+        <!-- 상단: 프로필 사진(가운데) + 설정 버튼(우측 상단) -->
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
             android:paddingVertical="16dp">
 
+            <!-- 프로필 사진: 정중앙 -->
             <androidx.cardview.widget.CardView
                 android:layout_width="120dp"
                 android:layout_height="120dp"
                 app:cardCornerRadius="60dp"
                 app:cardElevation="8dp"
-                android:layout_centerHorizontal="true">
+                android:layout_centerInParent="true">
 
                 <ImageView
                     android:id="@+id/profile_image"
@@ -39,12 +39,13 @@
                     tools:src="@drawable/ic_user"/>
             </androidx.cardview.widget.CardView>
 
-            <!-- 우측 상단 설정 버튼 -->
+            <!-- 설정 버튼: 오른쪽 상단 -->
             <ImageButton
                 android:id="@+id/btn_settings"
                 android:layout_width="40dp"
                 android:layout_height="40dp"
                 android:layout_alignParentEnd="true"
+                android:layout_alignParentTop="true"
                 android:layout_margin="8dp"
                 android:background="@android:color/transparent"
                 android:contentDescription="설정"


### PR DESCRIPTION
 회원가입 시 **인증 전에는 '가입완료!' 미노출**, 인증 확인 시점(체크 화면)에서만 노출되도록 플로우 정리
- **이미 존재하는 이메일**로 재가입 시도하면 다이얼로그로
  - 로그인 화면 이동(이메일 프리필 + 안내 토스트),
  - 비밀번호 재설정 메일 발송,
  - (비번 일치 시) 인증 메일 재발송